### PR TITLE
Fix/optimistic draw connections

### DIFF
--- a/src/lib/context/CommentBtnsContextWrapper.js
+++ b/src/lib/context/CommentBtnsContextWrapper.js
@@ -5,7 +5,6 @@ export function CommentBtnsContextWrapper({
   comment,
   commentId,
   postId,
-  setDeleteOptimistically,
   comments,
   setComments,
 }) {
@@ -14,7 +13,6 @@ export function CommentBtnsContextWrapper({
       comment={comment}
       commentId={commentId}
       postId={postId}
-      setDeleteOptimistically={setDeleteOptimistically}
       comments={comments}
       setComments={setComments}
     >

--- a/src/lib/context/CommentContextProvider.js
+++ b/src/lib/context/CommentContextProvider.js
@@ -7,7 +7,6 @@ export function CommentContextProvider({
   comment,
   commentId,
   postId,
-  setDeleteOptimistically,
   comments,
   setComments,
   isReplyFormVis,
@@ -28,7 +27,6 @@ export function CommentContextProvider({
         comments,
         setComments,
         postId,
-        setDeleteOptimistically,
         formRef,
       }}
     >

--- a/src/ui/comment/Comment.js
+++ b/src/ui/comment/Comment.js
@@ -22,7 +22,6 @@ export function Comment({
   postId,
   renderChildren,
 }) {
-  const [deleteOptimistically, setDeleteOptimistically] = useState(false)
   const [isReplyFormVis, setIsReplyFormVis] = useState(false)
   const [isEditVisible, setIsEditVisible] = useState(false)
   const [targetCommentId, setTargetCommentId] = useState(null)
@@ -70,7 +69,6 @@ export function Comment({
       comment={comment}
       commentId={commentId}
       postId={rootPostId}
-      setDeleteOptimistically={setDeleteOptimistically}
       comments={comments}
       setComments={setComments}
       isReplyFormVis={isReplyFormVis}
@@ -84,8 +82,6 @@ export function Comment({
         id={commentId}
         style={{
           marginLeft: depth === 0 ? 0 : 8,
-
-          display: deleteOptimistically ? 'none' : 'block',
         }}
       >
         {/* comment accordion element */}

--- a/src/ui/comment/CommentOptMenu.js
+++ b/src/ui/comment/CommentOptMenu.js
@@ -8,15 +8,13 @@ import { useToastContext } from '@/lib/toasts/ToastProvider'
 import { DeleteCommentBtn } from '../buttons/DeleteCommentBtn'
 import { EditCommentBtn } from '../buttons/EditCommentBtn'
 import { FavoritesBtn } from '../buttons/FavoritesBtn'
+import { usePostContext } from '@/lib/context/PostContextProvider'
 
 export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
-  const {
-    isEditVisible,
-    setIsEditVisible,
-    comment,
-    commentId,
-    setDeleteOptimistically,
-  } = useCommentContext()
+  const { isEditVisible, setIsEditVisible, comment, commentId } =
+    useCommentContext()
+  const { setTriggerRebuild, comments, setComments } = usePostContext()
+  const [oldComments, setOldComments] = useState(null)
   const { data: session } = useSession()
   const { toastFunctions: toast } = useToastContext()
   const usersId = session?.user.id
@@ -29,6 +27,7 @@ export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
   })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // delete has its own response handling due to it triggering dismount of this commponent, but favorites still needs below effect for toast handling:
   useEffect(() => {
     if (response?.state === 'success') {
       toast.success(response.message)
@@ -41,16 +40,39 @@ export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
 
   async function onDeleteSubmit() {
     handleDeleteOptimistically()
+    setTriggerRebuild((counter) => counter + 1)
     const serverResponse = await deleteComment(commentId)
-    setResponse(serverResponse)
+    if (serverResponse.state === 'success') {
+      toast.success(serverResponse.message)
+    } else {
+      toast.error(serverResponse.message)
+      handleOptimisticallyDeleteError()
+    }
   }
 
   function handleDeleteOptimistically() {
-    setDeleteOptimistically(true)
+    setOldComments(comments)
+
+    let newComments = [...comments]
+    newComments = newComments.filter((comm) => comm._id !== commentId)
+
+    if (comment.parent.type === 'comment') {
+      newComments = newComments.map((comm) => {
+        if (comment.parent._id === comm._id) {
+          return {
+            ...comm,
+            replies: comm.replies.filter((replyId) => replyId !== commentId),
+          }
+        } else {
+          return comm
+        }
+      })
+    }
+    setComments(newComments)
   }
 
   function handleOptimisticallyDeleteError() {
-    setDeleteOptimistically(false)
+    setComments(oldComments)
   }
 
   return (

--- a/src/ui/comment/CommentReplyForm.js
+++ b/src/ui/comment/CommentReplyForm.js
@@ -89,6 +89,7 @@ export function CommentReplyForm({ parentType }) {
     setResponse(serverResponse)
     setIsReplyFormVis(!isReplyFormVis)
     setFormData(initialFormData)
+    setTriggerRebuild((counter) => counter + 1)
   }
 
   function handleEditorToggle() {


### PR DESCRIPTION
### Fix: Connection lines not updating after creating or deleting a comment

Fixed a bug where comment connection lines were not redrawn properly after creating or deleting a comment.

### Changes made:

- Added `setTriggerRebuild` to `CommentReplyForm` to globally trigger redraw of all comment connection lines when a new comment is submitted.
- Refactored optimistic delete logic:
  - Simply marking deleted comments with a flag was not enough — connection lines were still rendered.
  - Now, deleted comments are removed from the `comments` state entirely, ensuring the component tree re-renders correctly.
- Removed `deleteOptimistically` flag from state, as it's no longer needed.

