### PR TITLE
Migrated favoirtes logic to PostsPage and filterPosts() server action.

### DIFF
--- a/src/app/posts/favorites/page.js
+++ b/src/app/posts/favorites/page.js
@@ -1,175 +1,33 @@
 'use client'
 
-import { AuthorsDataProvider } from '@/lib/context/AuthorsDataProvider'
-import { filterFavorites } from '@/lib/db'
-import { FilterBtn } from '@/ui/buttons/FilterBtn'
-import { Comment } from '@/ui/comment/Comment'
-import { Loader } from '@/ui/loaders/Loader'
-import { PostShimmer } from '@/ui/loaders/PostShimmer'
-import { FilterFavoritesForm } from '@/ui/post/FilterFavoritesForm'
-import { Post } from '@/ui/post/Post'
-import { PostsSearch } from '@/ui/post/PostsSearch'
+import PostsPage from '@/app/posts/page'
 import { signIn, useSession } from 'next-auth/react'
-import { useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { useEffect, useRef } from 'react'
 
-export default function FavoritesPage({ searchParams }) {
-  const [posts, setPosts] = useState(null)
-  const [comments, setComments] = useState(null)
-  const [authorsData, setAuthorsData] = useState([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [isFilterFormVis, setIsFilterFormVis] = useState(false)
-  const [triggerReset, setTriggerReset] = useState(false)
-  const [fastQuery, setFastQuery] = useState(searchParams.fastQuery || '')
-  const [documentOrder, setDocumentOrder] = useState([])
+export default function FavoritesPage() {
+  const searchParams = useSearchParams()
+  const searchParamsObj = Object.fromEntries(searchParams.entries())
   const { data: session } = useSession()
   const signingIn = useRef(false)
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    async function fetchData() {
-      let filterData = searchParams
-      const fetchedData = await filterFavorites(filterData)
-      const sortedData = fetchedData.map((document) => ({
-        _id: document._id,
-        type: document.type,
-      }))
-      setDocumentOrder(sortedData)
-
-      const postsData = fetchedData.filter(
-        (document) => document.type === 'post',
-      )
-      const commentsData = fetchedData.filter(
-        (document) => document.type === 'comment',
-      )
-      setPosts(postsData)
-      setComments(commentsData)
-    }
-
     if (!session) {
-      //below code to fix firefox issues with calling signIn() in useEffect
-      //reference to github next-auth issue 9177:
+      //below code fixes firefox issues with calling signIn() in useEffect
       //https://github.com/nextauthjs/next-auth/issues/9177
       if (signingIn.current) return
       signingIn.current = true
       signIn()
       return
     }
-
-    if (session?.user?.id) {
-      fetchData().then(() => setIsLoading(false))
-    }
   }, [session])
 
-  useEffect(() => {
-    if (triggerReset) {
-      setFastQuery('')
-      setTriggerReset(false)
-    }
-  }, [triggerReset])
-
-  const allDocuments = documentOrder.map((document) => {
-    return document.type === 'post'
-      ? posts.find((post) => post._id === document._id)
-      : comments.find((comment) => comment._id === document._id)
-  })
-  const matchingDocuments = allDocuments
-    .filter(
-      (document) =>
-        (document.type === 'post' &&
-          document.title.toLowerCase().includes(fastQuery.toLowerCase())) ||
-        document.authorData.name
-          .toLowerCase()
-          .includes(fastQuery.toLowerCase()) ||
-        document.content.toLowerCase().includes(fastQuery.toLowerCase()),
-    )
-    .map((document) => ({ _id: document._id, type: document.type }))
-
   return (
-    <>
-      <AuthorsDataProvider
-        authorsData={authorsData}
-        setAuthorsData={setAuthorsData}
-      >
-        <div className="favorites-container mx-auto mt-2 xs:mt-8 xs:px-4 max-w-[800px]">
-          <div className="flex md:items-center md:h-10 below-xs:mr-2 mb-4">
-            <h1 className="grow below-md:hidden text-2xl font-semibold mr-4">
-              Favorites
-            </h1>
-            <PostsSearch
-              triggerReset={triggerReset}
-              setTriggerReset={setTriggerReset}
-              setFastQuery={setFastQuery}
-              isFilterFormVis={isFilterFormVis}
-              setIsFilterFormVis={setIsFilterFormVis}
-            />
-            <FilterBtn
-              isFilterFormVis={isFilterFormVis}
-              setIsFilterFormVis={setIsFilterFormVis}
-            />
-          </div>
-          {isFilterFormVis && (
-            <FilterFavoritesForm
-              enableActivityFilter={false}
-              setTriggerReset={setTriggerReset}
-              isFilterFormVis={isFilterFormVis}
-              setIsFilterFormVis={setIsFilterFormVis}
-              setPosts={setPosts}
-              setComments={setComments}
-              setDocumentOrder={setDocumentOrder}
-            />
-          )}
-
-          {matchingDocuments && (posts || comments) && (
-            <div className="flex flex-col items-center">
-              {matchingDocuments.map((sortingObj) => {
-                const document =
-                  sortingObj.type === 'post'
-                    ? posts.find((post) => post._id === sortingObj._id)
-                    : comments.find((comment) => comment._id === sortingObj._id)
-                if (!document) return null
-                return document.type === 'post' ? (
-                  <Post
-                    key={document._id}
-                    _id={document._id}
-                    postId={document._id}
-                    post={document}
-                    posts={posts}
-                    setPosts={setPosts}
-                    enableCommentBtn={true}
-                  />
-                ) : (
-                  <a
-                    href={`/posts/post/${document.rootPostId}#${document._id}`}
-                    key={document._id}
-                    _id={document._id}
-                    className="comment-anchor-container flex w-full pb-4 px-4 xs:my-2 xs:rounded-md xs:shadow-center-md border-gray-300 xs:border-white border-t xs:border-2 xs:hover:border-blue-300 xs:hover:shadow-center-lg hover:cursor-pointer"
-                  >
-                    <Comment
-                      comment={document}
-                      commentId={document._id}
-                      depth={1}
-                      comments={comments}
-                      setComments={setComments}
-                      renderChildren={false}
-                    />
-                  </a>
-                )
-              })}
-            </div>
-          )}
-          {isLoading && (
-            <>
-              <Loader />
-              <PostShimmer />
-              <PostShimmer />
-              <PostShimmer />
-            </>
-          )}
-          {!isLoading && matchingDocuments.length === 0 && (
-            <h2 className="text-xl m-4 italic">No documents found</h2>
-          )}
-        </div>
-      </AuthorsDataProvider>
-    </>
+    <PostsPage
+      searchParams={searchParamsObj}
+      pageTitle={'Favorite Posts'}
+      showFavorites={true}
+      disableCreateBtn={true}
+    />
   )
 }

--- a/src/app/user/[id]/posts/page.js
+++ b/src/app/user/[id]/posts/page.js
@@ -10,7 +10,6 @@ import { getUser } from '@/lib/actions/user'
 
 export default function UserProfile({ params, searchParams }) {
   const [userData, setUserData] = useState(null)
-  const displayedPostsAuthor = params.id
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -59,7 +58,7 @@ export default function UserProfile({ params, searchParams }) {
               pageTitle={''}
               disableCreateBtn={true}
               disableFilteringByAuthor={true}
-              displayedPostsAuthor={displayedPostsAuthor}
+              forceAuthorName={userData.name}
             />
           </div>
         </>

--- a/src/lib/actions/filter.js
+++ b/src/lib/actions/filter.js
@@ -1,8 +1,11 @@
 'use server'
 
+import { authOptions } from '@/app/api/auth/[...nextauth]/authOptions'
 import { connectToDatabase } from '@/lib/db'
 import Post from '@/lib/models/Post'
 import sanitize from 'mongo-sanitize'
+import { getServerSession } from 'next-auth'
+import User from '../models/User'
 
 export async function filterPosts({
   searchParams,
@@ -10,10 +13,6 @@ export async function filterPosts({
   forceAuthorName = null,
 }) {
   const emptyResutls = { posts: [], postsCount: 0 }
-
-  // !!!! delete onlyCurrentUserPosts from frontend, and handle it differently (onlyOneUserPosts + perma set author name)
-
-  // !!!! also change displayedPostsAuthor on frontend
 
   // check if data is send from fastQuery or filter:
   const fastQuery = sanitize(searchParams.fastQuery)
@@ -23,6 +22,9 @@ export async function filterPosts({
   if (typeof forceAuthorName !== 'string' || forceAuthorName.length > 20) {
     forceAuthorName = null
   }
+
+  // validate showFavorites
+  if (typeof showFavorites !== 'boolean') showFavorites = false
 
   // pass proper data to title, content and author:
   const title = useFastQuery ? fastQuery : sanitize(searchParams.title)
@@ -86,9 +88,29 @@ export async function filterPosts({
     $unwind: '$authorData',
   })
 
+  // find users favorites:
+  // User.favorites is array of objects {type: 'post', _id: string}
+  if (showFavorites) {
+    const session = await getServerSession(authOptions)
+    if (!session) return emptyResutls
+
+    const user = await User.findById(session.user.id).lean()
+    if (!user || !user?.favorites) return emptyResutls
+    // currently favorites can be type post only,
+    // but check .type for future compatibilty with other favorite.type's.
+    const favoritePostIds = user.favorites
+      .filter((fav) => fav.type === 'post')
+      .map((fav) => fav._id)
+
+    if (!favoritePostIds.length) return emptyResutls
+
+    pipeline.push({
+      $match: { _id: { $in: favoritePostIds } },
+    })
+  }
+
   // force only one authors posts:
   // note `^${...}$` is used to force exact match
-
   if (forceAuthorName) {
     pipeline.push({
       $match: {

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -15,14 +15,3 @@ export async function connectToDatabase() {
     throw new Error('Error in connecting to mongodb')
   }
 }
-
-export async function filterFavorites(params) {
-  const queryString = new URLSearchParams(params).toString()
-
-  const res = await fetch(`/api/posts/favorites/filter?${queryString}`, {
-    method: 'GET',
-    cache: 'no-store',
-  })
-  if (!res.ok) return null
-  return res.json()
-}

--- a/src/ui/comment/CommentButtons.js
+++ b/src/ui/comment/CommentButtons.js
@@ -8,8 +8,14 @@ import { CommentLikeBtn } from '../buttons/CommentLikeBtn'
 import { CommentMenuBtn } from '../buttons/CommentMenuBtn'
 import { CommentEditForm } from './CommentEditForm'
 import { CommentReplyForm } from './CommentReplyForm'
+import { useSession } from 'next-auth/react'
+import { useCommentContext } from '@/lib/context/CommentContextProvider'
 
 export function CommentButtons() {
+  const { comment } = useCommentContext()
+  const { data: session } = useSession()
+  const usersId = session?.user.id
+  const isUsersComment = usersId === comment.user_id
   return (
     <>
       <div className="comment-btns-container flex items-center ml-4">
@@ -24,7 +30,7 @@ export function CommentButtons() {
         />
         <ReplyBtn className="comment-btn-reply" />
         <ShareCommentBtn className="comment-btn-share" />
-        <CommentMenuBtn className="comment-btn-menu" />
+        {isUsersComment && <CommentMenuBtn className="comment-btn-menu" />}
       </div>
       <CommentReplyForm className="comment-reply-form" parentType="comment" />
       <CommentEditForm className="comment-edit-form" />

--- a/src/ui/comment/CommentOptMenu.js
+++ b/src/ui/comment/CommentOptMenu.js
@@ -7,7 +7,6 @@ import { useCommentContext } from '@/lib/context/CommentContextProvider'
 import { useToastContext } from '@/lib/toasts/ToastProvider'
 import { DeleteCommentBtn } from '../buttons/DeleteCommentBtn'
 import { EditCommentBtn } from '../buttons/EditCommentBtn'
-import { FavoritesBtn } from '../buttons/FavoritesBtn'
 import { usePostContext } from '@/lib/context/PostContextProvider'
 
 export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
@@ -19,7 +18,6 @@ export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
   const { toastFunctions: toast } = useToastContext()
   const usersId = session?.user.id
   const isUsersComment = usersId === comment.user_id
-  const documentId = commentId
 
   const [response, setResponse] = useState({
     state: null,
@@ -93,14 +91,6 @@ export function CommentOptMenu({ isMenuVisible, setIsMenuVisible }) {
                 onDeleteSubmit={onDeleteSubmit}
               />
             </>
-          )}
-          {session && (
-            <FavoritesBtn
-              type={'comment'}
-              setIsMenuVisible={setIsMenuVisible}
-              setResponse={setResponse}
-              documentId={documentId}
-            />
           )}
         </div>
       )}


### PR DESCRIPTION
## Migrate favorites logic to `PostsPage` and `filterPosts`

This PR migrates the favorites logic from separate components and a dedicated API route to the `PostsPage` and `filterPosts` server action. The main goal is to centralize the logic and make the code easier to scale and maintain.

### Changes:
- Removed the old `FavoritesPage` and replaced it with a simple wrapper that passes props to `PostsPage`.
- Removed the `filterFavorites` helper function.
- Added favorites handling to the `filterPosts` server action.
- Removed logic that allowed adding `comments` to favorites (on both frontend and backend). Now only `posts` can be favorited.  
  At the same time, ensured that the server logic remains extensible for supporting other data types in the future.
